### PR TITLE
Script para Asteroids

### DIFF
--- a/Assets/Scripts/Asteroid.cs
+++ b/Assets/Scripts/Asteroid.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using System.Collections;
+
+
+
+public class Asteroid : MonoBehaviour{
+	public Rigidbody corpo;
+	public Collider colisor;
+	
+	[Tooltip("O som que tocará quando o asteroide explodir")]
+	public AudioClip somDaExplosao;
+	
+	
+	public int danoDaColisao = 10;
+	public int velocidade = 10;
+	
+	
+	public void Start(){
+		Vector3 direcao = gameObject.transform.forward;
+		corpo.AddForce(direcao*velocidade*Time.deltaTime, ForceMode.VelocityChange);
+		}
+	
+	public void OnCollisionEnter(Collision colisao){
+		if(colisao.gameObject.CompareTag("Player") ){
+			Danificavel jogador = colisao.gameObject.GetComponent<Danificavel>();
+      if(jogador){
+        atingeJogador();
+      }
+
+		}
+	}
+	
+	private void atingeJogador(){
+		jogador.RecebeDano(danoDaColisao, TipoDeDano.COLISAO);
+		AudioSource.PlayClipAtPoint(somDaExplosao, transform.position);
+		Destroy(gameObject);
+	}
+}


### PR DESCRIPTION
Esse script faz com que o Asteroid inicie o jogo se movendo para frente com uma velocidade específica. Ao atingir o jogador ele faz um barulho e causa dano do tipo colisão(supondo que o jogador tenha um componente "Danificavel").

OBS: Ainda falta colocar um componente "Danificavel" no asteroide.